### PR TITLE
fix: align explorer types with SDK domain models

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -227,7 +227,7 @@ function App() {
         )}
         
         {view === 'identity' && (
-          <IdentityView />
+          <IdentityView onFiberClick={handleFiberSelect} />
         )}
         
         {view === 'contracts' && (

--- a/src/components/AgentModal.tsx
+++ b/src/components/AgentModal.tsx
@@ -32,11 +32,15 @@ export function AgentModal({ address, onClose, onFiberClick }: AgentModalProps) 
   const completedContracts = allContracts.filter(c => c.state === 'COMPLETED').length;
   const activeContracts = allContracts.filter(c => c.state === 'ACTIVE' || c.state === 'PROPOSED').length;
 
+  // State colors aligned with SDK AgentState enum
   const getStateColor = (state: string) => {
     switch (state) {
       case 'ACTIVE': return 'text-[var(--green)]';
-      case 'REGISTERED': return 'text-[var(--orange)]';
-      case 'WITHDRAWN': return 'text-[var(--red)]';
+      case 'REGISTERED': return 'text-yellow-400';
+      case 'CHALLENGED': return 'text-orange-400';
+      case 'SUSPENDED': return 'text-[var(--red)]';
+      case 'PROBATION': return 'text-purple-400';
+      case 'WITHDRAWN': return 'text-gray-500';
       default: return 'text-[var(--text-muted)]';
     }
   };
@@ -237,28 +241,44 @@ export function AgentModal({ address, onClose, onFiberClick }: AgentModalProps) 
                   {fibers.length === 0 ? (
                     <p className="text-[var(--text-muted)] py-4 text-center">No fibers owned</p>
                   ) : (
-                    fibers.map(fiber => (
-                      <button
-                        key={fiber.fiberId}
-                        onClick={() => onFiberClick?.(fiber.fiberId)}
-                        className="w-full p-3 bg-[var(--bg-elevated)] rounded-lg border border-[var(--border)] text-left hover:border-[var(--accent)] transition-colors"
-                      >
-                        <div className="flex items-center justify-between mb-1">
-                          <span className="text-xs px-2 py-0.5 rounded bg-purple-500/20 text-purple-400">
-                            {fiber.workflowType}
-                          </span>
-                          <span className={`text-xs px-2 py-0.5 rounded ${
-                            fiber.status === 'ACTIVE' ? 'bg-green-500/20 text-green-400' : 'bg-gray-500/20 text-gray-400'
-                          }`}>{fiber.currentState}</span>
-                        </div>
-                        <div className="text-sm font-mono text-[var(--text-muted)] truncate">
-                          {fiber.fiberId}
-                        </div>
-                        <div className="text-xs text-[var(--text-muted)] mt-1">
-                          Seq #{fiber.sequenceNumber} • {new Date(fiber.updatedAt).toLocaleDateString()}
-                        </div>
-                      </button>
-                    ))
+                    fibers.map(fiber => {
+                      // Fiber status colors aligned with SDK FiberStatus enum
+                      const getStatusColor = (status: string) => {
+                        switch (status) {
+                          case 'ACTIVE': return 'bg-green-500/20 text-green-400';
+                          case 'ARCHIVED': return 'bg-blue-500/20 text-blue-400';
+                          case 'FAILED': return 'bg-red-500/20 text-red-400';
+                          default: return 'bg-gray-500/20 text-gray-400';
+                        }
+                      };
+                      return (
+                        <button
+                          key={fiber.fiberId}
+                          onClick={() => onFiberClick?.(fiber.fiberId)}
+                          className="w-full p-3 bg-[var(--bg-elevated)] rounded-lg border border-[var(--border)] text-left hover:border-[var(--accent)] transition-colors"
+                        >
+                          <div className="flex items-center justify-between mb-1">
+                            <span className="text-xs px-2 py-0.5 rounded bg-purple-500/20 text-purple-400">
+                              {fiber.workflowType}
+                            </span>
+                            <div className="flex items-center gap-2">
+                              <span className={`text-xs px-2 py-0.5 rounded ${getStatusColor(fiber.status)}`}>
+                                {fiber.status}
+                              </span>
+                              <span className="text-xs text-[var(--text-muted)]">
+                                {fiber.currentState}
+                              </span>
+                            </div>
+                          </div>
+                          <div className="text-sm font-mono text-[var(--text-muted)] truncate">
+                            {fiber.fiberId}
+                          </div>
+                          <div className="text-xs text-[var(--text-muted)] mt-1">
+                            Seq #{fiber.sequenceNumber} • {new Date(fiber.updatedAt).toLocaleDateString()}
+                          </div>
+                        </button>
+                      );
+                    })
                   )}
                 </div>
               )}

--- a/src/components/AgentSearch.tsx
+++ b/src/components/AgentSearch.tsx
@@ -44,12 +44,15 @@ export function AgentSearch({ initialSelectedAgent }: AgentSearchProps) {
 
   const agents = activeSearch && searchResults ? searchResults.searchAgents : allAgents?.agents;
 
+  // State colors aligned with SDK AgentState enum
   const getStateColor = (state: Agent['state']) => {
     switch (state) {
       case 'ACTIVE': return 'bg-[var(--green)]';
-      case 'PENDING': return 'bg-[var(--orange)]';
-      case 'PROBATION': return 'bg-[var(--orange)]';
+      case 'REGISTERED': return 'bg-yellow-500';
+      case 'CHALLENGED': return 'bg-orange-500';
+      case 'PROBATION': return 'bg-purple-500';
       case 'SUSPENDED': return 'bg-[var(--red)]';
+      case 'WITHDRAWN': return 'bg-gray-600';
       default: return 'bg-[var(--text-muted)]';
     }
   };

--- a/src/components/InteractionGraph.tsx
+++ b/src/components/InteractionGraph.tsx
@@ -150,14 +150,16 @@ export function InteractionGraph({ onAgentClick, width = 600, height = 400 }: In
     return { nodes, links };
   }, [data]);
 
-  // Color based on agent state
+  // Color based on agent state - aligned with SDK AgentState enum
   const getNodeColor = useCallback((node: GraphNode) => {
     switch (node.state) {
-      case 'ACTIVE': return '#22c55e';
-      case 'PENDING': return '#f97316';
-      case 'PROBATION': return '#eab308';
-      case 'SUSPENDED': return '#ef4444';
-      default: return '#a855f7';
+      case 'ACTIVE': return '#22c55e';     // green
+      case 'REGISTERED': return '#eab308'; // yellow
+      case 'CHALLENGED': return '#f97316'; // orange
+      case 'PROBATION': return '#a855f7';  // purple
+      case 'SUSPENDED': return '#ef4444';  // red
+      case 'WITHDRAWN': return '#6b7280';  // gray
+      default: return '#9ca3af';           // light gray
     }
   }, []);
 

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -8,12 +8,15 @@ interface LeaderboardProps {
 }
 
 export function Leaderboard({ agents, loading, onAgentClick }: LeaderboardProps) {
+  // State colors aligned with SDK AgentState enum
   const getStateColor = (state: Agent['state']) => {
     switch (state) {
       case 'ACTIVE': return 'text-[var(--green)]';
-      case 'PENDING': return 'text-[var(--orange)]';
-      case 'PROBATION': return 'text-[var(--orange)]';
+      case 'REGISTERED': return 'text-yellow-400';
+      case 'CHALLENGED': return 'text-orange-400';
+      case 'PROBATION': return 'text-purple-400';
       case 'SUSPENDED': return 'text-[var(--red)]';
+      case 'WITHDRAWN': return 'text-gray-500';
       default: return 'text-[var(--text-muted)]';
     }
   };

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -229,6 +229,43 @@ export const AGENT_UPDATED_SUB = gql`
 `;
 
 // ============ TYPES ============
+// Types aligned with ottochain-sdk protobuf definitions (source of truth)
+
+/**
+ * Agent lifecycle states - matches AgentState enum from SDK
+ * @see ottochain-sdk/src/generated/ottochain/apps/identity/v1/agent_pb.ts
+ */
+export type AgentState = 
+  | 'UNSPECIFIED'
+  | 'REGISTERED'   // Initial state after registration (was incorrectly 'PENDING')
+  | 'ACTIVE'       // Activated and participating
+  | 'CHALLENGED'   // Under dispute/challenge
+  | 'SUSPENDED'    // Challenge upheld, temporarily suspended
+  | 'PROBATION'    // Recovering from suspension
+  | 'WITHDRAWN';   // Voluntarily exited (terminal)
+
+/**
+ * Contract lifecycle states - matches ContractState enum from SDK
+ * @see ottochain-sdk/src/generated/ottochain/apps/contracts/v1/contract_pb.ts
+ */
+export type ContractState =
+  | 'UNSPECIFIED'
+  | 'PROPOSED'     // Awaiting counterparty acceptance
+  | 'ACTIVE'       // Both parties agreed, in progress
+  | 'COMPLETED'    // Successfully fulfilled (terminal)
+  | 'REJECTED'     // Counterparty declined (terminal)
+  | 'DISPUTED'     // Under dispute resolution
+  | 'CANCELLED';   // Cancelled by proposer before acceptance (terminal)
+
+/**
+ * Fiber lifecycle status - matches FiberStatus enum from SDK
+ * @see ottochain-sdk/src/generated/ottochain/v1/fiber_pb.ts
+ */
+export type FiberStatus =
+  | 'UNSPECIFIED'
+  | 'ACTIVE'       // Fiber is live and processing
+  | 'ARCHIVED'     // Fiber is archived (terminal state reached)
+  | 'FAILED';      // Fiber encountered a fatal error
 
 export interface NetworkStats {
   totalAgents: number;
@@ -252,7 +289,7 @@ export interface AgentContract {
   contractId: string;
   proposer?: { address: string; displayName: string | null };
   counterparty?: { address: string; displayName: string | null };
-  state: 'PROPOSED' | 'ACTIVE' | 'COMPLETED' | 'REJECTED' | 'DISPUTED';
+  state: ContractState;
   proposedAt: string;
   completedAt: string | null;
 }
@@ -261,7 +298,7 @@ export interface AgentFiber {
   fiberId: string;
   workflowType: string;
   currentState: string;
-  status: string;
+  status: FiberStatus;
   sequenceNumber: number;
   updatedAt: string;
 }
@@ -271,7 +308,7 @@ export interface Agent {
   publicKey: string;
   displayName: string | null;
   reputation: number;
-  state: 'PENDING' | 'ACTIVE' | 'PROBATION' | 'SUSPENDED';
+  state: AgentState;
   createdAt: string;
   platformLinks?: PlatformLink[];
   attestationsReceived?: Attestation[];
@@ -281,7 +318,7 @@ export interface Agent {
 }
 
 export interface PlatformLink {
-  platform: 'DISCORD' | 'TELEGRAM' | 'TWITTER' | 'GITHUB';
+  platform: 'DISCORD' | 'TELEGRAM' | 'TWITTER' | 'GITHUB' | 'CUSTOM';
   platformUserId: string;
   platformUsername: string | null;
   verified: boolean;
@@ -304,7 +341,7 @@ export interface Contract {
   contractId: string;
   proposer: Agent;
   counterparty: Agent;
-  state: 'PROPOSED' | 'ACCEPTED' | 'COMPLETED' | 'REJECTED' | 'DISPUTED';
+  state: ContractState;
   terms: Record<string, unknown>;
   proposedAt: string;
   acceptedAt: string | null;


### PR DESCRIPTION
## Problem
Explorer UI crashes when clicking on fibers in Agent Identity view due to type mismatches between SDK protobuf types (source of truth) and GraphQL frontend definitions.

## Changes
- **AgentState enum**: Changed PENDING→REGISTERED, added CHALLENGED/WITHDRAWN
- **ContractState**: Added missing CANCELLED state
- **FiberStatus**: Added proper enum with ACTIVE/ARCHIVED/FAILED
- **Fiber navigation**: Fixed click handlers in IdentityView (resolves crashes)
- **Type safety**: All components now use SDK-aligned state enums

## Testing
- ✅ TypeScript compiles without errors
- ✅ Production build succeeds  
- ✅ Fiber click navigation works (no more crashes)
- ✅ All agent/contract states use canonical SDK values

## Impact
Fixes the primary user-visible bug where clicking fibers crashed the view, and establishes type safety between frontend and domain model.

Closes the fiber click crash issue from Agent Identity leaderboard.