### PR TITLE
chore(deps): bump @ottochain/sdk to v2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@apollo/client": "^3.13.5",
     "@dicebear/collection": "^9.4.2",
     "@dicebear/core": "^9.4.2",
-    "@ottochain/sdk": "2.2.5",
+    "@ottochain/sdk": "2.7.0",
     "graphql": "^16.13.2",
     "graphql-ws": "^6.0.8",
     "react": "^19.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^9.4.2
         version: 9.4.2
       '@ottochain/sdk':
-        specifier: 2.2.5
-        version: 2.2.5(@stardust-collective/dag4@2.8.1)
+        specifier: 2.7.0
+        version: 2.7.0(@stardust-collective/dag4@2.8.1)
       graphql:
         specifier: ^16.13.2
         version: 16.13.2
@@ -219,11 +219,19 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@bufbuild/protobuf@2.11.0':
-    resolution: {integrity: sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==}
+  '@bufbuild/protobuf@2.12.1':
+    resolution: {integrity: sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==}
 
-  '@constellation-network/metagraph-sdk@0.2.0':
-    resolution: {integrity: sha512-QpQwk3JW0fsP/sc/ke12TYEKUkFdEmOhcNLY3C41vncb6Pjxc+PoAJsNbp18BfXsjphZXeOL83aps6XRA07OPQ==}
+  '@constellation-network/metagraph-sdk-core@1.8.0-rc.7':
+    resolution: {integrity: sha512-dshRWUlVES5W4JnouDrXxHmN1n5Ma83801sQo48jhp4GAPMNHL48k9s1VS6QbW6R4B8340yXR5HbGFdOPOB1RA==}
+    engines: {node: '>=20.19.0'}
+
+  '@constellation-network/metagraph-sdk-jlvm@1.8.0-rc.7':
+    resolution: {integrity: sha512-eMzJGMCO9zWsS/+EMuhQSKaJZplFLh0QiQZqS66xdx6lqitxGFfFEBLcrfENthECxdxS+7Q1hTPL9TWnS0ejUw==}
+    engines: {node: '>=20.19.0'}
+
+  '@constellation-network/metagraph-sdk@1.8.0-rc.7':
+    resolution: {integrity: sha512-/8mYIHhwQrIPbGK9Def29fXUVv8hDvyLTJKqWnIK5FCjVndexEqJxoGsmZZVUhZtxpvw+KxjnfqkPwcOTGEgww==}
     engines: {node: '>=20.19.0'}
 
   '@csstools/color-helpers@6.0.2':
@@ -732,8 +740,8 @@ packages:
   '@noble/secp256k1@1.7.2':
     resolution: {integrity: sha512-/qzwYl5eFLH8OWIecQWM31qld2g1NfjgylK+TNhqtaUKP37Nm+Y+z30Fjhw0Ct8p9yCQEm2N3W/AckdIb3SMcQ==}
 
-  '@ottochain/sdk@2.2.5':
-    resolution: {integrity: sha512-3NUNIHH40mPzGcdlDrwQsPJO/CgGG/xOxtBL7RLiiN7ng/osfhX6PwgzBsQSjBd9omJ3SV98mYZ3xCT+lLE4BA==}
+  '@ottochain/sdk@2.7.0':
+    resolution: {integrity: sha512-hd2esfC2QWuBATxaxzfPGFTIyGHjxaus4Il0BDRL8CnDT/ChR2logDAnbt+X9R0Vvs3y/F2Je/gntZBEzci/xw==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@stardust-collective/dag4': ^2.6.0
@@ -1481,8 +1489,9 @@ packages:
   caniuse-lite@1.0.30001780:
     resolution: {integrity: sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==}
 
-  canonicalize@2.1.0:
-    resolution: {integrity: sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==}
+  canonicalize@3.0.0:
+    resolution: {integrity: sha512-yYLfHyDMIXRyRqsKBRLX023riFLpXY2YOfdtqKXZRZy9qsfOJ9U+4F9YZL7MEzL5+ziN2x2nlBvY/Voi3EBljA==}
+    engines: {node: '>=18'}
     hasBin: true
 
   canvas-color-tracker@1.3.2:
@@ -2994,11 +3003,12 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vary@1.1.2:
@@ -3225,6 +3235,9 @@ packages:
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
   '@adobe/css-tools@4.4.4': {}
@@ -3384,14 +3397,23 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@bufbuild/protobuf@2.11.0': {}
+  '@bufbuild/protobuf@2.12.1': {}
 
-  '@constellation-network/metagraph-sdk@0.2.0':
+  '@constellation-network/metagraph-sdk-core@1.8.0-rc.7':
     dependencies:
       '@noble/curves': 2.0.1
       '@noble/hashes': 2.0.1
       bs58: 6.0.0
-      canonicalize: 2.1.0
+
+  '@constellation-network/metagraph-sdk-jlvm@1.8.0-rc.7':
+    dependencies:
+      '@noble/curves': 2.0.1
+      '@noble/hashes': 2.0.1
+
+  '@constellation-network/metagraph-sdk@1.8.0-rc.7':
+    dependencies:
+      '@constellation-network/metagraph-sdk-core': 1.8.0-rc.7
+      '@noble/hashes': 2.0.1
 
   '@csstools/color-helpers@6.0.2': {}
 
@@ -3777,16 +3799,18 @@ snapshots:
 
   '@noble/secp256k1@1.7.2': {}
 
-  '@ottochain/sdk@2.2.5(@stardust-collective/dag4@2.8.1)':
+  '@ottochain/sdk@2.7.0(@stardust-collective/dag4@2.8.1)':
     dependencies:
-      '@bufbuild/protobuf': 2.11.0
-      '@constellation-network/metagraph-sdk': 0.2.0
+      '@bufbuild/protobuf': 2.12.1
+      '@constellation-network/metagraph-sdk': 1.8.0-rc.7
+      '@constellation-network/metagraph-sdk-jlvm': 1.8.0-rc.7
+      '@noble/hashes': 1.8.0
       '@stardust-collective/dag4': 2.8.1
       '@stardust-collective/dag4-keystore': 2.8.1
-      canonicalize: 2.1.0
+      canonicalize: 3.0.0
       js-sha256: 0.11.1
       js-sha512: 0.9.0
-      zod: 3.25.76
+      zod: 4.4.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -4498,7 +4522,7 @@ snapshots:
 
   caniuse-lite@1.0.30001780: {}
 
-  canonicalize@2.1.0: {}
+  canonicalize@3.0.0: {}
 
   canvas-color-tracker@1.3.2:
     dependencies:
@@ -6278,3 +6302,5 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.3.6: {}
+
+  zod@4.4.3: {}


### PR DESCRIPTION
Automated SDK version bump triggered by `@ottochain/sdk` release.

## Changes
- `@ottochain/sdk` → `2.7.0`

---
*Triggered by: repository_dispatch*
*Auto-merge enabled: will merge when CI passes*